### PR TITLE
Add Windows support and storage policy skip tag

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -4,11 +4,19 @@ name: functions-markdown-agent
 version: 0.1.0
 hooks:
   prepackage:
-    shell: pwsh
-    run: ./infra/hooks/prepackage.ps1
+    windows:
+      shell: pwsh
+      run: ./infra/hooks/prepackage.ps1
+    posix:
+      shell: sh
+      run: ./infra/hooks/prepackage.sh
   postpackage:
-    shell: pwsh
-    run: Remove-Item -Recurse -Force ./infra/tmp -ErrorAction SilentlyContinue
+    windows:
+      shell: pwsh
+      run: Remove-Item -Recurse -Force ./infra/tmp -ErrorAction SilentlyContinue
+    posix:
+      shell: sh
+      run: rm -rf ./infra/tmp
 services:
   api:
     project: ./infra/tmp

--- a/azure.yaml
+++ b/azure.yaml
@@ -4,11 +4,11 @@ name: functions-markdown-agent
 version: 0.1.0
 hooks:
   prepackage:
-    shell: sh
-    run: ./infra/hooks/prepackage.sh
+    shell: pwsh
+    run: ./infra/hooks/prepackage.ps1
   postpackage:
-    shell: sh
-    run: rm -rf ./infra/tmp
+    shell: pwsh
+    run: Remove-Item -Recurse -Force ./infra/tmp -ErrorAction SilentlyContinue
 services:
   api:
     project: ./infra/tmp

--- a/infra/hooks/prepackage.ps1
+++ b/infra/hooks/prepackage.ps1
@@ -1,0 +1,28 @@
+$ErrorActionPreference = "Stop"
+
+$TMP_DIR = "infra/tmp"
+
+if (Test-Path $TMP_DIR) {
+    Write-Host "Cleaning existing $TMP_DIR..."
+    Remove-Item -Recurse -Force "$TMP_DIR/*"
+} else {
+    Write-Host "Creating $TMP_DIR..."
+    New-Item -ItemType Directory -Path $TMP_DIR -Force | Out-Null
+}
+
+Write-Host "Copying src contents to $TMP_DIR..."
+Copy-Item -Recurse -Force "src/*" $TMP_DIR
+
+Write-Host "Copying infra/assets contents to $TMP_DIR..."
+Copy-Item -Recurse -Force "infra/assets/*" $TMP_DIR
+
+$extraReq = Join-Path $TMP_DIR "extra-requirements.txt"
+$mainReq = Join-Path $TMP_DIR "requirements.txt"
+if (Test-Path $extraReq) {
+    Write-Host "Merging extra-requirements.txt into requirements.txt..."
+    Add-Content -Path $mainReq -Value ""
+    Get-Content $extraReq | Add-Content -Path $mainReq
+    Remove-Item $extraReq
+}
+
+Write-Host "prepackage completed successfully."

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -208,7 +208,9 @@ module storage 'br/public:avm/res/storage/storage-account:0.8.3' = {
     }
     minimumTlsVersion: 'TLS1_2'  // Enforcing TLS 1.2 for better security
     location: location
-    tags: tags
+    tags: union(tags, {
+      'Az.Sec.DisableLocalAuth.Storage::Skip': 'Azure Files SMB mount requires shared key access for session persistence'
+    })
   }
 }
 


### PR DESCRIPTION
## Changes

- **Cross-platform `azure.yaml` hooks**: Updated `prepackage` and `postpackage` hooks to support both Windows (`pwsh`) and POSIX (`sh`) using platform-specific sub-keys.
- **New PowerShell prepackage script**: Added `infra/hooks/prepackage.ps1` as the Windows equivalent of the existing `prepackage.sh`.
- **Storage policy skip tag**: Added `Az.Sec.DisableLocalAuth.Storage::Skip` tag to the storage account in `infra/main.bicep`, since Azure Files SMB mounting requires shared key access for session persistence.